### PR TITLE
pip 9.0.2 and 10 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ bin/
 include/
 
 .idea/
+.pytest_cache/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,10 @@
 Changelog
 =========
 
-Unreleased Changes
+0.1.2 (2018-03-18)
 ------------------
 
+* Fix `Issue #5 <https://github.com/jantman/versionfinder/issues/5>`_ where ``import pip`` fails if ``requests`` has previously been imported. Also proactive fix for pip10 changes.
 * Multiple test fixes
 
 0.1.1 (2017-06-16)

--- a/versionfinder/version.py
+++ b/versionfinder/version.py
@@ -35,5 +35,5 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 ##################################################################################
 """
 
-VERSION = '0.1.1'
+VERSION = '0.1.2'
 PROJECT_URL = 'https://github.com/jantman/versionfinder'

--- a/versionfinder/versionfinder.py
+++ b/versionfinder/versionfinder.py
@@ -45,10 +45,13 @@ from contextlib import contextmanager
 from .versioninfo import VersionInfo
 
 try:
-    import pip
+    import pip._internal as pip
 except ImportError:
-    # this is used within try blocks; NBD if they fail
-    pass
+    try:
+        import pip
+    except (ImportError, KeyError):
+        # this is used within try blocks; NBD if they fail
+        pass
 
 try:
     import pkg_resources


### PR DESCRIPTION
This provides a workaround for https://github.com/pypa/pip/issues/5079 where a KeyError is raised if ``requests`` has already been imported and we try to ``import pip`` using pip==9.0.2. It also provides a proactive fix for the major refactor in pip10.