### PR TITLE
Bug fix, Python version deprecations, build fixes, version 1.0.0

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,4 +12,5 @@ exclude_lines =
     if sys.version_info.+
     raise NotImplementedError
     except ImportError:
+    except \(ImportError, KeyError\):
     .*# nocoverage.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       env: TOXENV=py35-unit
     - python: "3.6"
       env: TOXENV=py36-unit
-    - python: "2.7"
+    - python: "3.7"
       env: TOXENV=docs
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ cache: pip
 
 matrix:
   include:
-    - python: "2.7"
-      env: TOXENV=py27-acceptance
-    - python: "3.4"
-      env: TOXENV=py34-acceptance
     - python: "3.5"
       env: TOXENV=py35-acceptance
     - python: "3.6"
@@ -17,10 +13,6 @@ matrix:
       env: TOXENV=py37-acceptance
     - python: "3.8"
       env: TOXENV=py38-acceptance
-    - python: "2.7"
-      env: TOXENV=py27-unit
-    - python: "3.4"
-      env: TOXENV=py34-unit
     - python: "3.5"
       env: TOXENV=py35-unit
     - python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
       env: TOXENV=py35-acceptance
     - python: "3.6"
       env: TOXENV=py36-acceptance
+    - python: "3.7"
+      env: TOXENV=py37-acceptance
+    - python: "3.8"
+      env: TOXENV=py38-acceptance
     - python: "2.7"
       env: TOXENV=py27-unit
     - python: "3.4"
@@ -21,6 +25,10 @@ matrix:
       env: TOXENV=py35-unit
     - python: "3.6"
       env: TOXENV=py36-unit
+    - python: "3.7"
+      env: TOXENV=py37-unit
+    - python: "3.8"
+      env: TOXENV=py38-unit
     - python: "3.7"
       env: TOXENV=docs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
   include:
     - python: "2.7"
       env: TOXENV=py27-acceptance
-    - python: "3.3"
-      env: TOXENV=py33-acceptance
     - python: "3.4"
       env: TOXENV=py34-acceptance
     - python: "3.5"
@@ -17,8 +15,6 @@ matrix:
       env: TOXENV=py36-acceptance
     - python: "2.7"
       env: TOXENV=py27-unit
-    - python: "3.3"
-      env: TOXENV=py33-unit
     - python: "3.4"
       env: TOXENV=py34-unit
     - python: "3.5"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,9 +5,11 @@ Unreleased Changes
 ------------------
 
 * Stop testing Python 3.3 and drop official support for it.
+* Multiple pip10 fixes.
 * Test fixes:
 
   * Always install latest versions of ``coverage`` and ``pytest``.
+  * Switch docs build to py37
 
 0.1.3 (2018-03-18)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 Unreleased Changes
 ------------------
 
+**Important:**
+
+* Fix `Issue #7 <https://github.com/jantman/versionfinder/issues/7>`_ where certain new versions of pip throw an AttributeError on import if running in Lambda (or other environments where ``sys.stdin`` is ``None``).
 * Stop testing Python 3.3 and drop official support for it.
 * Multiple pip10 fixes.
 * Test fixes:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,12 @@ Changelog
 Unreleased Changes
 ------------------
 
-**Important:**
+**Important:** in keeping with the scheduled end-of-life of various Python versions, versionfinder now only officially supports Python 3.5 or greater. A DeprecationWarning will be generated when run with versions before 3.5, and they are no longer tested.
 
 * Fix `Issue #7 <https://github.com/jantman/versionfinder/issues/7>`_ where certain new versions of pip throw an AttributeError on import if running in Lambda (or other environments where ``sys.stdin`` is ``None``).
 * Stop testing Python 3.3 and drop official support for it.
+* Stop testing Python 2.7 and 3.4.
+* Add DeprecationWarnings for any Python version < 3.5.
 * Multiple pip10 fixes.
 * Test fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Unreleased Changes
+------------------
+
+* Stop testing Python 3.3 and drop official support for it.
+* Test fixes:
+
+  * Always install latest versions of ``coverage`` and ``pytest``.
 
 0.1.3 (2018-03-18)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-Unreleased Changes
+1.0.0 (2019-10-27)
 ------------------
 
 **Important:** in keeping with the scheduled end-of-life of various Python versions, versionfinder now only officially supports Python 3.5 or greater. A DeprecationWarning will be generated when run with versions before 3.5, and they are no longer tested.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Unreleased Changes
 
   * Always install latest versions of ``coverage`` and ``pytest``.
   * Switch docs build to py37
+  * Begin testing under py37 and py38
 
 0.1.3 (2018-03-18)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -49,8 +49,9 @@ tag or commit from a git repo, or has local changes not committed to git.
 Requirements
 ------------
 
-* Python 2.7, or Python 3.3+. Python 3.0-3.2 is not supported. Python 2.6 should
-  function, but will not return detailed git information and is not tested.
+* Python 2.7, or Python 3.4+. Python 3.0-3.2 is not supported. Python 3.3 was supported
+  but is no longer tested. Python 2.6 might function, but will not return detailed
+  git information and is not tested.
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,7 @@ Guidelines
 Testing
 -------
 
-Testing is done via `pytest <http://pytest.org/latest/>`_, driven by `tox <https://tox.readthedocs.org/>`_.
+Testing is done via `pytest <https://docs.pytest.org/en/latest/>`_, driven by `tox <https://tox.readthedocs.org/>`_.
 
 * testing is as simple as:
 

--- a/docs/source/versionfinder.rst
+++ b/docs/source/versionfinder.rst
@@ -2,9 +2,9 @@ versionfinder package
 =====================
 
 .. automodule:: versionfinder
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
@@ -14,4 +14,3 @@ Submodules
    versionfinder.version
    versionfinder.versionfinder
    versionfinder.versioninfo
-

--- a/docs/source/versionfinder.version.rst
+++ b/docs/source/versionfinder.version.rst
@@ -2,6 +2,6 @@ versionfinder.version module
 ============================
 
 .. automodule:: versionfinder.version
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/versionfinder.versionfinder.rst
+++ b/docs/source/versionfinder.versionfinder.rst
@@ -2,6 +2,6 @@ versionfinder.versionfinder module
 ==================================
 
 .. automodule:: versionfinder.versionfinder
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/versionfinder.versioninfo.rst
+++ b/docs/source/versionfinder.versioninfo.rst
@@ -2,6 +2,6 @@ versionfinder.versioninfo module
 ================================
 
 .. automodule:: versionfinder.versioninfo
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/setup.py
+++ b/setup.py
@@ -42,12 +42,11 @@ with open('README.rst') as fh:
     long_description = fh.read()
 
 classifiers = [
-    'Development Status :: 4 - Beta',
+    'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',
     'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
     'Operating System :: OS Independent',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Topic :: Software Development',
     'Topic :: Software Development :: Libraries',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36,py37,py38}-{unit,acceptance},docs
+envlist = {py35,py36,py37,py38}-{unit,acceptance},docs
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py33,py34,py35,py36}-{unit,acceptance},docs
+envlist = {py27,py34,py35,py36}-{unit,acceptance},docs
 
 [testenv]
 deps =
@@ -7,8 +7,7 @@ deps =
   execnet
   pep8
   py
-  py33: pytest<3.3.0
-  {py27,py34,py35,py36}-{unit,acceptance}: pytest>=3.3.0
+  pytest
   pytest-cache
   pytest-cov
   pytest-pep8
@@ -19,8 +18,7 @@ deps =
   requests
   virtualenv
   backoff
-  py36: coverage
-  {py27,py33,py34,py35}-{unit,acceptance}: coverage==3.7.1
+  coverage
 
 passenv=TRAVIS*
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36}-{unit,acceptance},docs
+envlist = {py27,py34,py35,py36,py37,py38}-{unit,acceptance},docs
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ deps =
   pygments
   sphinx
   sphinx_rtd_theme
-basepython = python2.7
+basepython = python3.7
 commands =
     python --version
     virtualenv --version

--- a/versionfinder/tests/test_acceptance.py
+++ b/versionfinder/tests/test_acceptance.py
@@ -221,7 +221,7 @@ class AcceptanceHelpers(object):
                 'config',
                 'user.email'
             ]).strip()
-        except subprocess.CalledProcessError as ex:
+        except subprocess.CalledProcessError:
             res = None
         if res != '' and res is not None:
             print("Got git config user.email as %s" % res)

--- a/versionfinder/tests/test_versionfinder.py
+++ b/versionfinder/tests/test_versionfinder.py
@@ -710,9 +710,9 @@ class TestFindPipInfo(BaseTest):
             req='foo==4.5.6'
         )
 
-        with patch('%s.pip.get_installed_distributions' % pbm
+        with patch('%s.get_installed_distributions' % pbm
                    ) as mock_pgid:
-            with patch('%s.pip.FrozenRequirement.from_dist' % pbm
+            with patch('%s.FrozenRequirement.from_dist' % pbm
                        ) as mock_from_dist:
                 with patch('%s._dist_version_url' % pb) as mock_dist_vu:
                     mock_pgid.return_value = installed_dists
@@ -734,9 +734,9 @@ class TestFindPipInfo(BaseTest):
             req='awslimitchecker==0.1.0'
         )
 
-        with patch('%s.pip.get_installed_distributions' % pbm
+        with patch('%s.get_installed_distributions' % pbm
                    ) as mock_pgid:
-            with patch('%s.pip.FrozenRequirement.from_dist' % pbm
+            with patch('%s.FrozenRequirement.from_dist' % pbm
                        ) as mock_from_dist:
                 with patch('%s._dist_version_url' % pb) as mock_dist_vu:
                     mock_pgid.return_value = installed_dists
@@ -760,9 +760,9 @@ class TestFindPipInfo(BaseTest):
             req=req_str
         )
 
-        with patch('%s.pip.get_installed_distributions' % pbm
+        with patch('%s.get_installed_distributions' % pbm
                    ) as mock_pgid:
-            with patch('%s.pip.FrozenRequirement.from_dist' % pbm
+            with patch('%s.FrozenRequirement.from_dist' % pbm
                        ) as mock_from_dist:
                 with patch('%s._dist_version_url' % pb) as mock_dist_vu:
                     mock_pgid.return_value = installed_dists
@@ -787,9 +787,9 @@ class TestFindPipInfo(BaseTest):
             req=req_str
         )
 
-        with patch('%s.pip.get_installed_distributions' % pbm
+        with patch('%s.get_installed_distributions' % pbm
                    ) as mock_pgid:
-            with patch('%s.pip.FrozenRequirement.from_dist' % pbm
+            with patch('%s.FrozenRequirement.from_dist' % pbm
                        ) as mock_from_dist:
                 with patch('%s._dist_version_url' % pb) as mock_dist_vu:
                     mock_pgid.return_value = installed_dists

--- a/versionfinder/version.py
+++ b/versionfinder/version.py
@@ -35,5 +35,5 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 ##################################################################################
 """
 
-VERSION = '0.1.3'
+VERSION = '1.0.0'
 PROJECT_URL = 'https://github.com/jantman/versionfinder'

--- a/versionfinder/versionfinder.py
+++ b/versionfinder/versionfinder.py
@@ -46,27 +46,33 @@ import warnings
 
 from .versioninfo import VersionInfo
 
+# Note: we catch all exceptions here because of
+# https://github.com/jantman/versionfinder/issues/7 - some pip versions
+# throw an import-time AttributeError when running in Lambda, or other
+# environments where sys.stdin is None. Per that issue, the right thing to
+# do is never fail if pip can't be imported.
+# This was fixed in https://github.com/pypa/pip/pull/7118 / pip 19.3
 try:
     from pip._internal.operations.freeze import FrozenRequirement
-except (ImportError, KeyError):
+except Exception:
     try:
         from pip._internal import FrozenRequirement
-    except (ImportError, KeyError):
+    except Exception:
         try:
             from pip import FrozenRequirement
-        except (ImportError, KeyError):
+        except Exception:
             # this is used within try blocks; NBD if they fail
             pass
 
 try:
     from pip._internal.utils.misc import get_installed_distributions
-except (ImportError, KeyError):
+except Exception:
     try:
         from pip._internal import get_installed_distributions
-    except (ImportError, KeyError):
+    except Exception:
         try:
             from pip import get_installed_distributions
-        except (ImportError, KeyError):
+        except Exception:
             # this is used within try blocks; NBD if they fail
             pass
 

--- a/versionfinder/versionfinder.py
+++ b/versionfinder/versionfinder.py
@@ -189,7 +189,10 @@ class VersionFinder(object):
             pip_info = self._find_pip_info()
         except Exception:
             # we NEVER want this to crash the program
-            logger.debug('Caught exception running _find_pip_info()')
+            logger.debug(
+                'Caught exception running _find_pip_info()',
+                exc_info=True
+            )
             pip_info = {}
         logger.debug("pip info: %s", pip_info)
         for k, v in pip_info.items():
@@ -275,7 +278,10 @@ class VersionFinder(object):
         res['version'] = ver
         res['url'] = url
         # this is a bit of an ugly, lazy hack...
-        req = FrozenRequirement.from_dist(dist, [])
+        try:
+            req = FrozenRequirement.from_dist(dist, [])
+        except TypeError:  # nocoverage
+            req = FrozenRequirement.from_dist(dist)
         logger.debug('pip FrozenRequirement: %s', req)
         res['requirement'] = str(req.req)
         return res

--- a/versionfinder/versionfinder.py
+++ b/versionfinder/versionfinder.py
@@ -54,7 +54,7 @@ from .versioninfo import VersionInfo
 # This was fixed in https://github.com/pypa/pip/pull/7118 / pip 19.3
 try:
     from pip._internal.operations.freeze import FrozenRequirement
-except Exception:
+except Exception:  # nocoverage
     try:
         from pip._internal import FrozenRequirement
     except Exception:
@@ -66,7 +66,7 @@ except Exception:
 
 try:
     from pip._internal.utils.misc import get_installed_distributions
-except Exception:
+except Exception:  # nocoverage
     try:
         from pip._internal import get_installed_distributions
     except Exception:

--- a/versionfinder/versionfinder.py
+++ b/versionfinder/versionfinder.py
@@ -147,10 +147,13 @@ class VersionFinder(object):
         logger.debug('package_dir: %s' % self.package_dir)
         self._pip_locations = []
         self._pkg_resources_locations = []
-        if sys.version_info[0] == 3 and sys.version_info[1] == 3:  # nocoverage
+        if (
+            sys.version_info[0] < 3 or
+            sys.version_info[0] == 3 and sys.version_info[1] < 5
+        ):  # nocoverage
             warnings.warn(
                 'The versionfinder package no longer supports Python %d.%d; '
-                'please switch to Python 2.7 or Python >= 3.4.' % (
+                'please switch to Python 3.5 or newer.' % (
                     sys.version_info[0], sys.version_info[1]
                 ),
                 DeprecationWarning

--- a/versionfinder/versionfinder.py
+++ b/versionfinder/versionfinder.py
@@ -37,10 +37,12 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 ################################################################################
 """
 
+import sys
 import os
 import logging
 import inspect
 from contextlib import contextmanager
+import warnings
 
 from .versioninfo import VersionInfo
 
@@ -81,6 +83,10 @@ except Exception:  # nocoverage
     pass
 
 logger = logging.getLogger(__name__)
+
+warnings.filterwarnings(
+    action="always", category=DeprecationWarning, module=__name__
+)
 
 
 class VersionFinder(object):
@@ -135,6 +141,14 @@ class VersionFinder(object):
         logger.debug('package_dir: %s' % self.package_dir)
         self._pip_locations = []
         self._pkg_resources_locations = []
+        if sys.version_info[0] == 3 and sys.version_info[1] == 3:  # nocoverage
+            warnings.warn(
+                'The versionfinder package no longer supports Python %d.%d; '
+                'please switch to Python 2.7 or Python >= 3.4.' % (
+                    sys.version_info[0], sys.version_info[1]
+                ),
+                DeprecationWarning
+            )
 
     def find_package_version(self):
         """

--- a/versionfinder/versioninfo.py
+++ b/versionfinder/versioninfo.py
@@ -243,7 +243,7 @@ class VersionInfo(object):
 
         If the distribution is installed via git and pip recognizes the git
         source, return the pip requirement string specifying the git URL and
-        commit, with an '*' appended if :py:attr:`~.git_is_dirty` is True.
+        commit, with an '*' appended if :py:meth:`~.git_is_dirty` is True.
 
         Otherwise, return a string of the form:
 
@@ -251,7 +251,7 @@ class VersionInfo(object):
 
         Where URL is the remote URL, ref is the tag name if the repo is checked
         out to a commit that matches a tag or else the commit hex SHA, and '*'
-        is appended if :py:attr:`~.git_is_dirty` is True.
+        is appended if :py:meth:`~.git_is_dirty` is True.
 
         :return: description of the git repo remote and state
         :rtype: str
@@ -283,7 +283,7 @@ class VersionInfo(object):
         """
         Return a long version and installation specifier string of the form:
 
-        If :py:attr:`~.git_str` == '':
+        If :py:meth:`~.git_str` == '':
 
             SHORT_STR
 
@@ -291,8 +291,8 @@ class VersionInfo(object):
 
             SHORT_STR (GIT_STR)
 
-        Where ``SHORT_STR`` is :py:attr:`~.short_str` and ``GIT_STR`` is
-        :py:attr:`~.git_str`.
+        Where ``SHORT_STR`` is :py:meth:`~.short_str` and ``GIT_STR`` is
+        :py:meth:`~.git_str`.
 
         :return: long version/installation specifier string
         :rtype: str


### PR DESCRIPTION
This PR wraps up quite a few changes:

-   Fix #7 where certain new versions of pip throw an AttributeError on import if running in Lambda (or other environments where `sys.stdin` is `None`).
-   Stop testing Python 3.3 and drop official support for it.
-   Stop testing Python 2.7 and 3.4.
-   Add DeprecationWarnings for any Python version < 3.5.
-   Multiple pip10 fixes.
-   Test fixes:
    -   Always install latest versions of `coverage` and `pytest`.
    -   Switch docs build to py37
    -   Begin testing under py37 and py38

This also bumps to 1.0.0, since this has been working in the wild for quite a few years.