### PR TITLE
Suppress pip.subprocessor logging - fixes https://github.com/jantman/awslimitchecker/issues/465

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.1.1 (2020-09-18)
+------------------
+
+* Unless :py:class:`~.VersionFinder` is constructed with the ``log=True`` option, completely disable the ``pip.subprocessor`` logger. This will suppress annoying critical-level log messages generated on systems which do not have ``git`` in the PATH.
+
 1.1.0 (2020-09-18)
 ------------------
 

--- a/versionfinder/version.py
+++ b/versionfinder/version.py
@@ -35,5 +35,5 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 ##################################################################################
 """
 
-VERSION = '1.1.0'
+VERSION = '1.1.1'
 PROJECT_URL = 'https://github.com/jantman/versionfinder'

--- a/versionfinder/versionfinder.py
+++ b/versionfinder/versionfinder.py
@@ -118,8 +118,9 @@ class VersionFinder(object):
         :type package_file: str
         :param log: If not set to True, the "versionfinder" and "pip" loggers
           will be set to a level of :py:const:`logging.CRITICAL` to suppress
-          log output. If set to True, you will see a LOT of debug-level log
-          output, for debugging the internals of versionfinder.
+          log output. The "pip.subprocessor" logger will be completely disabled.
+          If set to True, you will see a LOT of debug-level log output, for
+          debugging the internals of versionfinder.
         :type log: bool
         :param caller_frame: If the call to this method is wrapped by something
           else, this should be the stack frame representing the original caller.
@@ -132,6 +133,8 @@ class VersionFinder(object):
             pip_log = logging.getLogger("pip")
             pip_log.setLevel(logging.CRITICAL)
             pip_log.propagate = True
+            pip_s_log = logging.getLogger('pip.subprocessor')
+            pip_s_log.disabled = True
         logger.debug("Finding package version for: %s", package_name)
         self.package_name = package_name
         if package_file is not None:


### PR DESCRIPTION
This suppresses the ``pip.subprocessor`` logging, which outputs a CRITICAL message if the ``git`` binary can't be found.

This fixes https://github.com/jantman/awslimitchecker/issues/465